### PR TITLE
Update CaptureActivity.java

### DIFF
--- a/src/android/com/phonegap/plugins/barcodescanner/CaptureActivity.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/CaptureActivity.java
@@ -59,6 +59,8 @@ public class CaptureActivity extends Activity implements
                 setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
             } else if (scanOrientation == PORTRAIT) {
                 setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+            } else {
+                getIntent().putExtra(Intents.Scan.ORIENTATION_LOCKED, false);
             }
 
             // Load and use views afterwards


### PR DESCRIPTION
When no orientation is specified, the orientation should not be locked.

